### PR TITLE
Fix some tests for JTable

### DIFF
--- a/tests/unit/core/mock/application/base.php
+++ b/tests/unit/core/mock/application/base.php
@@ -30,6 +30,7 @@ class TestMockApplicationBase
 			'triggerEvent',
 			'loadDispatcher',
 			'loadIdentity',
+			'getDispatcher'
 		);
 	}
 

--- a/tests/unit/suites/libraries/cms/helper/JHelperContentTest.php
+++ b/tests/unit/suites/libraries/cms/helper/JHelperContentTest.php
@@ -54,7 +54,11 @@ class JHelperContentTest extends TestCaseDatabase
 		$this->saveFactoryState();
 
 		$this->object = new JHelperContent;
-		JFactory::$application = $this->getMockCmsApp();
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/helper/JHelperTest.php
+++ b/tests/unit/suites/libraries/cms/helper/JHelperTest.php
@@ -54,7 +54,11 @@ class JHelperTest extends TestCaseDatabase
 		$this->saveFactoryState();
 
 		$this->object = new JHelper;
-		JFactory::$application = $this->getMockCmsApp();
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/html/JHtmlUserTest.php
+++ b/tests/unit/suites/libraries/cms/html/JHtmlUserTest.php
@@ -17,6 +17,43 @@
 class JHtmlUserTest extends TestCaseDatabase
 {
 	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.1
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		// Get the mocks
+		$this->saveFactoryState();
+
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
+	}
+
+	/**
+	 * Tears down the fixture, for example, closes a network connection.
+	 * This method is called after a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.1
+	 */
+	protected function tearDown()
+	{
+		$this->restoreFactoryState();
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Gets the data set to be loaded into the database during setup
 	 *
 	 * @return  PHPUnit_Extensions_Database_DataSet_CsvDataSet

--- a/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
+++ b/tests/unit/suites/libraries/cms/installer/JInstallerTest.php
@@ -31,7 +31,30 @@ class JInstallerTest extends TestCaseDatabase
 	{
 		parent::setUp();
 
+		$this->saveFactoryState();
+
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
+
 		$this->object = new JInstaller;
+	}
+
+	/**
+	 * Overrides the parent tearDown method.
+	 *
+	 * @return  void
+	 *
+	 * @see     PHPUnit_Framework_TestCase::tearDown()
+	 * @since   12.1
+	 */
+	protected function tearDown()
+	{
+		$this->restoreFactoryState();
+
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/table/JTableContenttypeTest.php
+++ b/tests/unit/suites/libraries/cms/table/JTableContenttypeTest.php
@@ -34,7 +34,30 @@ class JTableContenttypeTest extends TestCaseDatabase
 	{
 		parent::setUp();
 
+		$this->saveFactoryState();
+
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
+
 		$this->object = new JTableContenttype(static::$driver);
+	}
+
+	/**
+	 * Overrides the parent tearDown method.
+	 *
+	 * @return  void
+	 *
+	 * @see     PHPUnit_Framework_TestCase::tearDown()
+	 * @since   12.1
+	 */
+	protected function tearDown()
+	{
+		$this->restoreFactoryState();
+
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/unit/suites/libraries/cms/table/JTableCorecontentTest.php
+++ b/tests/unit/suites/libraries/cms/table/JTableCorecontentTest.php
@@ -39,6 +39,12 @@ class JTableCorecontentTest extends TestCaseDatabase
 
 		JFactory::$session = $this->getMockSession();
 
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
+
 		$this->object = new JTableCorecontent(static::$driver);
 	}
 

--- a/tests/unit/suites/libraries/cms/ucm/JUcmContentTest.php
+++ b/tests/unit/suites/libraries/cms/ucm/JUcmContentTest.php
@@ -36,7 +36,11 @@ class JUcmContentTest extends TestCaseDatabase
 
 		$this->saveFactoryState();
 
-		JFactory::$application = $this->getMockWeb();
+		$mockApp = $this->getMockWeb();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
 
 		$this->object = new JUcmContent(JTable::getInstance('Content'), 'com_content.article');
 	}

--- a/tests/unit/suites/libraries/joomla/access/JAccessTest.php
+++ b/tests/unit/suites/libraries/joomla/access/JAccessTest.php
@@ -468,6 +468,14 @@ class JAccessTest extends TestCaseDatabase
 	{
 		parent::setUp();
 
+		$this->saveFactoryState();
+
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
+
 		// Clear the static caches.
 		JAccess::clearStatics();
 
@@ -490,6 +498,7 @@ class JAccessTest extends TestCaseDatabase
 	protected function tearDown()
 	{
 		$this->_cleanupTestFiles();
+		$this->restoreFactoryState();
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/table/JTableExtensionTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableExtensionTest.php
@@ -39,6 +39,12 @@ class JTableExtensionTest extends TestCaseDatabase
 
 		JFactory::$session = $this->getMockSession();
 
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
+
 		$this->object = new JTableExtension(self::$driver);
 	}
 

--- a/tests/unit/suites/libraries/joomla/table/JTableLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableLanguageTest.php
@@ -37,6 +37,12 @@ class JTableLanguageTest extends TestCaseDatabase
 		// Get the mocks
 		$this->saveFactoryState();
 
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
+
 		JFactory::$session = $this->getMockSession();
 
 		$this->object = new JTableLanguage(self::$driver);

--- a/tests/unit/suites/libraries/joomla/table/JTableNestedTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableNestedTest.php
@@ -791,9 +791,13 @@ class JTableNestedTest extends TestCaseDatabase
 	{
 		parent::setup();
 
-// 		$this->saveFactoryState();
+		$this->saveFactoryState();
 
-// 		JFactory::$session = $this->getMockSession();
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
 
 		$this->class = new NestedTable(self::$driver);
 	}
@@ -809,7 +813,7 @@ class JTableNestedTest extends TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-// 		$this->restoreFactoryState();
+ 		$this->restoreFactoryState();
 
 		parent::tearDown();
 	}

--- a/tests/unit/suites/libraries/joomla/table/JTableTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableTest.php
@@ -36,6 +36,14 @@ class JTableTest extends TestCaseDatabase
 	{
 		parent::setUp();
 
+		$this->saveFactoryState();
+
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
+
 		$this->object = new TableDbTestComposite(TestCaseDatabase::$driver);
 	}
 
@@ -49,6 +57,7 @@ class JTableTest extends TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
+		$this->restoreFactoryState();
 		parent::tearDown();
 	}
 

--- a/tests/unit/suites/libraries/joomla/table/JTableUserTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableUserTest.php
@@ -20,6 +20,43 @@ require_once JPATH_PLATFORM . '/joomla/table/user.php';
 class JTableUserTest extends TestCaseDatabase
 {
 	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.1
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		// Get the mocks
+		$this->saveFactoryState();
+
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
+	}
+
+	/**
+	 * Tears down the fixture, for example, closes a network connection.
+	 * This method is called after a test is executed.
+	 *
+	 * @return  void
+	 *
+	 * @since   3.1
+	 */
+	protected function tearDown()
+	{
+		$this->restoreFactoryState();
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Gets the data set to be loaded into the database during setup
 	 *
 	 * @return  PHPUnit_Extensions_Database_DataSet_CsvDataSet

--- a/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
+++ b/tests/unit/suites/libraries/joomla/user/JUserHelperTest.php
@@ -35,6 +35,12 @@ class JUserHelperTest extends TestCaseDatabase
 	{
 		parent::setUp();
 
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
+
 		$this->saveFactoryState();
 	}
 

--- a/tests/unit/suites/libraries/joomla/user/JUserTest.php
+++ b/tests/unit/suites/libraries/joomla/user/JUserTest.php
@@ -38,10 +38,15 @@ class JUserTest extends TestCaseDatabase
 
 		$this->saveFactoryState();
 
-		$this->object = new JUser('42');
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
 
-		JFactory::$application = $this->getMockCmsApp();
 		JFactory::$session     = $this->getMockSession();
+
+		$this->object = new JUser('42');
 	}
 
 	/**

--- a/tests/unit/suites/libraries/legacy/model/JModelLegacyTest.php
+++ b/tests/unit/suites/libraries/legacy/model/JModelLegacyTest.php
@@ -38,6 +38,16 @@ class JModelLegacyTest extends TestCaseDatabase
 	public function setUp()
 	{
 		parent::setUp();
+
+		// Get the mocks
+		$this->saveFactoryState();
+
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
+
 		$this->fixture = JModelLegacy::getInstance('Lead', 'TestModel');
 	}
 
@@ -51,6 +61,7 @@ class JModelLegacyTest extends TestCaseDatabase
 	public function tearDown()
 	{
 		$this->fixture = null;
+		$this->restoreFactoryState();
 		parent::tearDown();
 	}
 

--- a/tests/unit/suites/libraries/legacy/table/JTableContentTest.php
+++ b/tests/unit/suites/libraries/legacy/table/JTableContentTest.php
@@ -40,6 +40,11 @@ class JTableContentTest extends TestCaseDatabase
 		$this->saveFactoryState();
 
 		JFactory::$session = $this->getMockSession();
+		$mockApp = $this->getMockCmsApp();
+		$mockApp->expects($this->any())
+			->method('getDispatcher')
+			->willReturn($this->getMockDispatcher());
+		JFactory::$application = $mockApp;
 
 		$this->object = new JTableContent(self::$driver);
 	}


### PR DESCRIPTION
This should fix a lot of the existing failures in https://travis-ci.org/joomla-projects/joomla-pythagoras/jobs/73704434

126 Errors + 1 Failure -> 4 Errors

The remaining errors are just due to the fact we need to rework mockRegister function in the MockDispatcher which is currently trying to convert a callable into a string :D (https://github.com/joomla-projects/joomla-pythagoras/blob/feature-orthogonal/tests/unit/core/mock/dispatcher.php#L136)
