### PR TITLE
Rename methods that start with an underscore in JFilter

### DIFF
--- a/libraries/joomla/filter/input.php
+++ b/libraries/joomla/filter/input.php
@@ -280,11 +280,11 @@ class JFilterInput
 				break;
 
 			case 'STRING':
-				$result = (string) $this->_remove($this->_decode((string) $source));
+				$result = (string) $this->remove($this->decode((string) $source));
 				break;
 
 			case 'HTML':
-				$result = (string) $this->_remove((string) $source);
+				$result = (string) $this->remove((string) $source);
 				break;
 
 			case 'ARRAY':
@@ -320,7 +320,7 @@ class JFilterInput
 						// Filter element for XSS and other 'bad' code etc.
 						if (is_string($value))
 						{
-							$source[$key] = $this->_remove($this->_decode($value));
+							$source[$key] = $this->remove($this->decode($value));
 						}
 					}
 
@@ -332,7 +332,7 @@ class JFilterInput
 					if (is_string($source) && !empty($source))
 					{
 						// Filter source for XSS and other 'bad' code etc.
-						$result = $this->_remove($this->_decode($source));
+						$result = $this->remove($this->decode($source));
 					}
 					else
 					{
@@ -649,14 +649,14 @@ class JFilterInput
 	 *
 	 * @since   11.1
 	 */
-	protected function _remove($source)
+	protected function remove($source)
 	{
 		$loopCounter = 0;
 
 		// Iteration provides nested tag protection
-		while ($source != $this->_cleanTags($source))
+		while ($source != $this->cleanTags($source))
 		{
-			$source = $this->_cleanTags($source);
+			$source = $this->cleanTags($source);
 			$loopCounter++;
 		}
 
@@ -672,10 +672,10 @@ class JFilterInput
 	 *
 	 * @since   11.1
 	 */
-	protected function _cleanTags($source)
+	protected function cleanTags($source)
 	{
 		// First, pre-process this for illegal characters inside attribute values
-		$source = $this->_escapeAttributeValues($source);
+		$source = $this->escapeAttributeValues($source);
 
 		// In the beginning we don't really have a tag, so everything is postTag
 		$preTag = null;
@@ -854,7 +854,7 @@ class JFilterInput
 				if (!$isCloseTag)
 				{
 					// Open or single tag
-					$attrSet = $this->_cleanAttributes($attrSet);
+					$attrSet = $this->cleanAttributes($attrSet);
 					$preTag .= '<' . $tagName;
 
 					for ($i = 0, $count = count($attrSet); $i < $count; $i++)
@@ -902,7 +902,7 @@ class JFilterInput
 	 *
 	 * @since   11.1
 	 */
-	protected function _cleanAttributes($attrSet)
+	protected function cleanAttributes($attrSet)
 	{
 		$newSet = array();
 
@@ -1005,7 +1005,7 @@ class JFilterInput
 	 *
 	 * @since   11.1
 	 */
-	protected function _decode($source)
+	protected function decode($source)
 	{
 		static $ttr;
 
@@ -1048,7 +1048,7 @@ class JFilterInput
 	 *
 	 * @since    11.1
 	 */
-	protected function _escapeAttributeValues($source)
+	protected function escapeAttributeValues($source)
 	{
 		$alreadyFiltered = '';
 		$remainder = $source;
@@ -1085,7 +1085,7 @@ class JFilterInput
 
 			// Escape bad chars
 			$attributeValue = str_replace($badChars, $escapedChars, $attributeValue);
-			$attributeValue = $this->_stripCSSExpressions($attributeValue);
+			$attributeValue = $this->stripCSSExpressions($attributeValue);
 			$alreadyFiltered .= substr($remainder, 0, $nextBefore) . $attributeValue . $quote;
 			$remainder = substr($remainder, $nextAfter + 1);
 		}
@@ -1103,7 +1103,7 @@ class JFilterInput
 	 *
 	 * @since   11.1
 	 */
-	protected function _stripCSSExpressions($source)
+	protected function stripCSSExpressions($source)
 	{
 		// Strip any comments out (in the form of /*...*/)
 		$test = preg_replace('#\/\*.*\*\/#U', '', $source);

--- a/libraries/joomla/filter/output.php
+++ b/libraries/joomla/filter/output.php
@@ -69,7 +69,7 @@ class JFilterOutput
 	{
 		$regex = 'href="([^"]*(&(amp;){0})[^"]*)*?"';
 
-		return preg_replace_callback("#$regex#i", array('JFilterOutput', '_ampReplaceCallback'), $input);
+		return preg_replace_callback("#$regex#i", array('JFilterOutput', 'ampReplaceCallback'), $input);
 	}
 
 	/**
@@ -168,7 +168,7 @@ class JFilterOutput
 	 *
 	 * @since   11.1
 	 */
-	public static function _ampReplaceCallback($m)
+	public static function ampReplaceCallback($m)
 	{
 		$rx = '&(?!amp;)';
 

--- a/libraries/joomla/filter/wrapper/output.php
+++ b/libraries/joomla/filter/wrapper/output.php
@@ -105,9 +105,9 @@ class JFilterWrapperOutput
 	 * @see     JFilterOutput::_ampReplaceCallback()
 	 * @since   3.4
 	 */
-	public function _ampReplaceCallback($m)
+	public function ampReplaceCallback($m)
 	{
-		return JFilterOutput::_ampReplaceCallback($m);
+		return JFilterOutput::ampReplaceCallback($m);
 	}
 
 	/**


### PR DESCRIPTION
This removes the underscore prefixing methods that should allow this package to be merged with it's framework counterpart
