### PR TITLE
Fix a lot of codestyle issues

### DIFF
--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -99,7 +99,10 @@ class TagsViewTag extends JViewLegacy
 				$results = JFactory::getApplication()->triggerEvent('onContentAfterTitle', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
 				$itemElement->event->afterDisplayTitle = trim(implode("\n", $results));
 
-				$results = JFactory::getApplication()->triggerEvent('onContentBeforeDisplay', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));
+				$results = JFactory::getApplication()->triggerEvent(
+					'onContentBeforeDisplay',
+					array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0)
+				);
 				$itemElement->event->beforeDisplayContent = trim(implode("\n", $results));
 
 				$results = JFactory::getApplication()->triggerEvent('onContentAfterDisplay', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0));

--- a/libraries/cms/Event/AbstractEvent.php
+++ b/libraries/cms/Event/AbstractEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -32,6 +32,8 @@ use BadMethodCallException;
  * This AbstractEvent class implements a mutable event which is allowed to change its arguments at runtime. This is
  * generally unadvisable. It's best to use AbstractImmutableEvent instead and constrict all your interaction to the
  * subject class.
+ *
+ * @since  4.0
  */
 abstract class AbstractEvent extends BaseEvent
 {
@@ -118,8 +120,8 @@ abstract class AbstractEvent extends BaseEvent
 	 * $value  is the value currently stored in the $arguments array of the event
 	 * It returns the value to return to the caller.
 	 *
-	 * @param   string $name    The argument name.
-	 * @param   mixed  $default The default value if not found.
+	 * @param   string  $name     The argument name.
+	 * @param   mixed   $default  The default value if not found.
 	 *
 	 * @return  mixed  The argument value or the default value.
 	 *
@@ -149,8 +151,8 @@ abstract class AbstractEvent extends BaseEvent
 	 * $value  is the value being set by the user
 	 * It returns the value to return to set in the $arguments array of the event.
 	 *
-	 * @param   string $key   Argument name.
-	 * @param   mixed  $value Value.
+	 * @param   string  $name   Argument name.
+	 * @param   mixed   $value  Value.
 	 *
 	 * @return  $this
 	 *

--- a/libraries/cms/Event/AbstractImmutableEvent.php
+++ b/libraries/cms/Event/AbstractImmutableEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -16,7 +16,8 @@ use BadMethodCallException;
 /**
  * This class implements the immutable base Event object used system-wide to offer orthogonality.
  *
- * @see Joomla\Cms\Event\AbstractEvent
+ * @see    Joomla\Cms\Event\AbstractEvent
+ * @since  4.0
  */
 class AbstractImmutableEvent extends AbstractEvent
 {

--- a/libraries/cms/Event/GenericEvent.php
+++ b/libraries/cms/Event/GenericEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -11,7 +11,11 @@ namespace Joomla\Cms\Event;
 
 defined('JPATH_PLATFORM') or die;
 
+/**
+ * Concrete implementation of the AbstractEvent class
+ *
+ * @since  4.0
+ */
 class GenericEvent extends AbstractEvent
 {
-
 }

--- a/libraries/cms/Event/Table/AbstractEvent.php
+++ b/libraries/cms/Event/Table/AbstractEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -17,14 +17,16 @@ use JTableInterface;
 
 /**
  * Event class for JTable's events
+ *
+ * @since  4.0
  */
 abstract class AbstractEvent extends AbstractImmutableEvent
 {
 	/**
 	 * Constructor.
 	 *
-	 * @param   string $name      The event name.
-	 * @param   array  $arguments The event arguments.
+	 * @param   string  $name       The event name.
+	 * @param   array   $arguments  The event arguments.
 	 *
 	 * @throws  BadMethodCallException
 	 *
@@ -39,7 +41,6 @@ abstract class AbstractEvent extends AbstractImmutableEvent
 
 		parent::__construct($name, $arguments);
 	}
-
 
 	/**
 	 * Setter for the subject argument

--- a/libraries/cms/Event/Table/AfterBindEvent.php
+++ b/libraries/cms/Event/Table/AfterBindEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -11,9 +11,11 @@ namespace Joomla\Cms\Event\Table;
 
 defined('JPATH_PLATFORM') or die;
 
-use BadMethodCallException;
-
+/**
+ * Event class for JTable's onAfterBind event
+ *
+ * @since  4.0
+ */
 class AfterBindEvent extends BeforeBindEvent
 {
-
 }

--- a/libraries/cms/Event/Table/AfterCheckinEvent.php
+++ b/libraries/cms/Event/Table/AfterCheckinEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -11,7 +11,11 @@ namespace Joomla\Cms\Event\Table;
 
 defined('JPATH_PLATFORM') or die;
 
+/**
+ * Event class for JTable's onAfterCheckin event
+ *
+ * @since  4.0
+ */
 class AfterCheckinEvent extends BeforeCheckinEvent
 {
-
 }

--- a/libraries/cms/Event/Table/AfterCheckoutEvent.php
+++ b/libraries/cms/Event/Table/AfterCheckoutEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -11,7 +11,11 @@ namespace Joomla\Cms\Event\Table;
 
 defined('JPATH_PLATFORM') or die;
 
+/**
+ * Event class for JTable's onAfterCheckout event
+ *
+ * @since  4.0
+ */
 class AfterCheckoutEvent extends BeforeCheckoutEvent
 {
-
 }

--- a/libraries/cms/Event/Table/AfterDeleteEvent.php
+++ b/libraries/cms/Event/Table/AfterDeleteEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -16,6 +16,8 @@ use JTableInterface;
 
 /**
  * Event class for JTable's onAfterDelete event
+ *
+ * @since  4.0
  */
 class AfterDeleteEvent extends AbstractEvent
 {

--- a/libraries/cms/Event/Table/AfterHitEvent.php
+++ b/libraries/cms/Event/Table/AfterHitEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -11,7 +11,11 @@ namespace Joomla\Cms\Event\Table;
 
 defined('JPATH_PLATFORM') or die;
 
+/**
+ * Event class for JTable's onAfterHit event
+ *
+ * @since  4.0
+ */
 class AfterHitEvent extends BeforeCheckinEvent
 {
-
 }

--- a/libraries/cms/Event/Table/AfterLoadEvent.php
+++ b/libraries/cms/Event/Table/AfterLoadEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -16,6 +16,8 @@ use JTableInterface;
 
 /**
  * Event class for JTable's onAfterLoad event
+ *
+ * @since  4.0
  */
 class AfterLoadEvent extends AbstractEvent
 {
@@ -27,8 +29,8 @@ class AfterLoadEvent extends AbstractEvent
 	 * result	boolean			Did the table record load succeed?
 	 * row		null|array		The values loaded from the database, null if it failed
 	 *
-	 * @param   string $name      The event name.
-	 * @param   array  $arguments The event arguments.
+	 * @param   string  $name       The event name.
+	 * @param   array   $arguments  The event arguments.
 	 *
 	 * @throws  BadMethodCallException
 	 */

--- a/libraries/cms/Event/Table/AfterMoveEvent.php
+++ b/libraries/cms/Event/Table/AfterMoveEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -15,6 +15,11 @@ use BadMethodCallException;
 use JTableInterface;
 use stdClass;
 
+/**
+ * Event class for JTable's onAfterMove event
+ *
+ * @since  4.0
+ */
 class AfterMoveEvent extends AbstractEvent
 {
 	/**

--- a/libraries/cms/Event/Table/AfterPublishEvent.php
+++ b/libraries/cms/Event/Table/AfterPublishEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -11,10 +11,13 @@ namespace Joomla\Cms\Event\Table;
 
 defined('JPATH_PLATFORM') or die;
 
-use BadMethodCallException;
 use JTableInterface;
 
+/**
+ * Event class for JTable's onAfterPublish event
+ *
+ * @since  4.0
+ */
 class AfterPublishEvent extends BeforePublishEvent
 {
-
 }

--- a/libraries/cms/Event/Table/AfterReorderEvent.php
+++ b/libraries/cms/Event/Table/AfterReorderEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -15,6 +15,11 @@ use BadMethodCallException;
 use JTableInterface;
 use stdClass;
 
+/**
+ * Event class for JTable's onAfterReorder event
+ *
+ * @since  4.0
+ */
 class AfterReorderEvent extends AbstractEvent
 {
 	/**

--- a/libraries/cms/Event/Table/AfterResetEvent.php
+++ b/libraries/cms/Event/Table/AfterResetEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -11,7 +11,11 @@ namespace Joomla\Cms\Event\Table;
 
 defined('JPATH_PLATFORM') or die;
 
+/**
+ * Event class for JTable's onAfterReset event
+ *
+ * @since  4.0
+ */
 class AfterResetEvent extends AbstractEvent
 {
-
 }

--- a/libraries/cms/Event/Table/AfterStoreEvent.php
+++ b/libraries/cms/Event/Table/AfterStoreEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -16,6 +16,8 @@ use JTableInterface;
 
 /**
  * Event class for JTable's onAfterStore event
+ *
+ * @since  4.0
  */
 class AfterStoreEvent extends AbstractEvent
 {

--- a/libraries/cms/Event/Table/BeforeBindEvent.php
+++ b/libraries/cms/Event/Table/BeforeBindEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -13,6 +13,11 @@ defined('JPATH_PLATFORM') or die;
 
 use BadMethodCallException;
 
+/**
+ * Event class for JTable's onBeforeBind event
+ *
+ * @since  4.0
+ */
 class BeforeBindEvent extends AbstractEvent
 {
 	/**

--- a/libraries/cms/Event/Table/BeforeCheckinEvent.php
+++ b/libraries/cms/Event/Table/BeforeCheckinEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -13,6 +13,11 @@ defined('JPATH_PLATFORM') or die;
 
 use BadMethodCallException;
 
+/**
+ * Event class for JTable's onBeforeCheckin event
+ *
+ * @since  4.0
+ */
 class BeforeCheckinEvent extends AbstractEvent
 {
 	/**

--- a/libraries/cms/Event/Table/BeforeCheckoutEvent.php
+++ b/libraries/cms/Event/Table/BeforeCheckoutEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -13,6 +13,11 @@ defined('JPATH_PLATFORM') or die;
 
 use BadMethodCallException;
 
+/**
+ * Event class for JTable's onBeforeCheckout event
+ *
+ * @since  4.0
+ */
 class BeforeCheckoutEvent extends AbstractEvent
 {
 	/**

--- a/libraries/cms/Event/Table/BeforeDeleteEvent.php
+++ b/libraries/cms/Event/Table/BeforeDeleteEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -16,6 +16,8 @@ use JTableInterface;
 
 /**
  * Event class for JTable's onBeforeDelete event
+ *
+ * @since  4.0
  */
 class BeforeDeleteEvent extends AbstractEvent
 {

--- a/libraries/cms/Event/Table/BeforeHitEvent.php
+++ b/libraries/cms/Event/Table/BeforeHitEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -11,7 +11,11 @@ namespace Joomla\Cms\Event\Table;
 
 defined('JPATH_PLATFORM') or die;
 
+/**
+ * Event class for JTable's onBeforeHit event
+ *
+ * @since  4.0
+ */
 class BeforeHitEvent extends BeforeCheckinEvent
 {
-
 }

--- a/libraries/cms/Event/Table/BeforeLoadEvent.php
+++ b/libraries/cms/Event/Table/BeforeLoadEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -16,6 +16,8 @@ use JTableInterface;
 
 /**
  * Event class for JTable's onBeforeLoad event
+ *
+ * @since  4.0
  */
 class BeforeLoadEvent extends AbstractEvent
 {

--- a/libraries/cms/Event/Table/BeforeMoveEvent.php
+++ b/libraries/cms/Event/Table/BeforeMoveEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -15,6 +15,11 @@ use BadMethodCallException;
 use JTableInterface;
 use JDatabaseQuery;
 
+/**
+ * Event class for JTable's onBeforeMove event
+ *
+ * @since  4.0
+ */
 class BeforeMoveEvent extends AbstractEvent
 {
 	/**

--- a/libraries/cms/Event/Table/BeforePublishEvent.php
+++ b/libraries/cms/Event/Table/BeforePublishEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -14,6 +14,11 @@ defined('JPATH_PLATFORM') or die;
 use BadMethodCallException;
 use JTableInterface;
 
+/**
+ * Event class for JTable's onBeforePublish event
+ *
+ * @since  4.0
+ */
 class BeforePublishEvent extends AbstractEvent
 {
 	/**

--- a/libraries/cms/Event/Table/BeforeReorderEvent.php
+++ b/libraries/cms/Event/Table/BeforeReorderEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -15,6 +15,11 @@ use BadMethodCallException;
 use JTableInterface;
 use JDatabaseQuery;
 
+/**
+ * Event class for JTable's onBeforeReorder event
+ *
+ * @since  4.0
+ */
 class BeforeReorderEvent extends AbstractEvent
 {
 	/**

--- a/libraries/cms/Event/Table/BeforeResetEvent.php
+++ b/libraries/cms/Event/Table/BeforeResetEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -11,7 +11,11 @@ namespace Joomla\Cms\Event\Table;
 
 defined('JPATH_PLATFORM') or die;
 
+/**
+ * Event class for JTable's onBeforeReset event
+ *
+ * @since  4.0
+ */
 class BeforeResetEvent extends AbstractEvent
 {
-
 }

--- a/libraries/cms/Event/Table/BeforeStoreEvent.php
+++ b/libraries/cms/Event/Table/BeforeStoreEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -16,6 +16,8 @@ use JTableInterface;
 
 /**
  * Event class for JTable's onBeforeStore event
+ *
+ * @since  4.0
  */
 class BeforeStoreEvent extends AbstractEvent
 {

--- a/libraries/cms/Event/Table/CheckEvent.php
+++ b/libraries/cms/Event/Table/CheckEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -11,7 +11,11 @@ namespace Joomla\Cms\Event\Table;
 
 defined('JPATH_PLATFORM') or die;
 
+/**
+ * Event class for JTable's onTableCheck event
+ *
+ * @since  4.0
+ */
 class CheckEvent extends AbstractEvent
 {
-
 }

--- a/libraries/cms/Event/Table/ObjectCreateEvent.php
+++ b/libraries/cms/Event/Table/ObjectCreateEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -11,7 +11,11 @@ namespace Joomla\Cms\Event\Table;
 
 defined('JPATH_PLATFORM') or die;
 
+/**
+ * Event class for JTable's onTableObjectCreate event
+ *
+ * @since  4.0
+ */
 class ObjectCreateEvent extends AbstractEvent
 {
-
 }

--- a/libraries/cms/Event/Table/SetNewTagsEvent.php
+++ b/libraries/cms/Event/Table/SetNewTagsEvent.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Libraries
- * @subpackage  Error
+ * @subpackage  Event
  *
  * @copyright   Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -17,9 +17,13 @@ use JTableInterface;
 /**
  * Event class for JTable's onSetNewTags event
  *
- * TODO This is only used in JModelAdmin::batchTag. We need to remove it but we can't use JTable::save as we don't want the table data to be saved. Maybe trigger the onBeforeStore event instead?
+ * TODO This is only used in JModelAdmin::batchTag. We need to remove it but we can't use
+ * JTable::save as we don't want the table data to be saved. Maybe trigger the onBeforeStore
+ * event instead?
+ *
+ * @since  4.0
  */
-class SetNewTagsEvent extends TableEvent
+class SetNewTagsEvent extends AbstractEvent
 {
 	/**
 	 * Constructor.

--- a/libraries/cms/captcha/captcha.php
+++ b/libraries/cms/captcha/captcha.php
@@ -59,7 +59,7 @@ class JCaptcha implements DispatcherAwareInterface
 		// Set the dispatcher
 		if (!is_object($dispatcher))
 		{
-			$dispatcher = new Dispatcher();
+			$dispatcher = new Dispatcher;
 		}
 
 		$this->setDispatcher($dispatcher);
@@ -113,7 +113,8 @@ class JCaptcha implements DispatcherAwareInterface
 	{
 		$event = new Event('onInit', [
 			'id' => $id
-		]);
+		]
+		);
 
 		try
 		{
@@ -158,7 +159,8 @@ class JCaptcha implements DispatcherAwareInterface
 			'name'	=> $name,
 			'id'	=> $id ? $id : $name,
 			'class' => $class ? 'class="' . $class . '"' : '',
-		]);
+		]
+		);
 
 		$result = $this->getDispatcher()->dispatch('onInit', $event);
 
@@ -185,7 +187,8 @@ class JCaptcha implements DispatcherAwareInterface
 
 		$event = new Event('onCheckAnswer', [
 			'code'	=> $code
-		]);
+		]
+		);
 
 		$result = $this->getDispatcher()->dispatch('onCheckAnswer', $event);
 

--- a/libraries/cms/editor/editor.php
+++ b/libraries/cms/editor/editor.php
@@ -77,7 +77,7 @@ class JEditor implements DispatcherAwareInterface
 		// Set the dispatcher
 		if (!is_object($dispatcher))
 		{
-			$dispatcher = new Dispatcher();
+			$dispatcher = new Dispatcher;
 		}
 
 		$this->setDispatcher($dispatcher);
@@ -92,7 +92,8 @@ class JEditor implements DispatcherAwareInterface
 			$newResult = (array) $newResult;
 
 			$event['result'] = array_merge($result, $newResult);
-		});
+		}
+		);
 
 		// Register the getContent event
 		$this->getDispatcher()->addListener('getContent', function(AbstractEvent $event) {
@@ -102,7 +103,8 @@ class JEditor implements DispatcherAwareInterface
 			$result[] = $this->getContent($editor);
 
 			$event['result'] = $result;
-		});
+		}
+		);
 
 		// Register the setContent event
 		$this->getDispatcher()->addListener('getContent', function(AbstractEvent $event) {
@@ -113,7 +115,8 @@ class JEditor implements DispatcherAwareInterface
 			$result[] = $this->setContent($editor, $html);
 
 			$event['result'] = $result;
-		});
+		}
+		);
 
 		// Register the save event
 		$this->getDispatcher()->addListener('save', function(AbstractEvent $event) {
@@ -123,7 +126,8 @@ class JEditor implements DispatcherAwareInterface
 			$result[] = $this->save($editor);
 
 			$event['result'] = $result;
-		});
+		}
+		);
 	}
 
 	/**

--- a/libraries/cms/installer/installer.php
+++ b/libraries/cms/installer/installer.php
@@ -664,7 +664,10 @@ class JInstaller extends JAdapter
 
 		// Fire the onExtensionBeforeUpdate event.
 		JPluginHelper::importPlugin('extension');
-		JFactory::getApplication()->triggerEvent('onExtensionBeforeUpdate', array('type' => $this->manifest->attributes()->type, 'manifest' => $this->manifest));
+		JFactory::getApplication()->triggerEvent(
+			'onExtensionBeforeUpdate',
+			array('type' => $this->manifest->attributes()->type, 'manifest' => $this->manifest)
+		);
 
 		// Run the update
 		$result = $adapter->update();

--- a/libraries/cms/plugin/helper.php
+++ b/libraries/cms/plugin/helper.php
@@ -136,10 +136,10 @@ abstract class JPluginHelper
 	 * Loads all the plugin files for a particular type if no specific plugin is specified
 	 * otherwise only the specific plugin is loaded.
 	 *
-	 * @param   string            $type        The plugin type, relates to the sub-directory in the plugins directory.
-	 * @param   string            $plugin      The plugin name.
-	 * @param   boolean           $autocreate  Autocreate the plugin.
-	 * @param   Dispatcher        $dispatcher  Optionally allows the plugin to use a different dispatcher.
+	 * @param   string      $type        The plugin type, relates to the sub-directory in the plugins directory.
+	 * @param   string      $plugin      The plugin name.
+	 * @param   boolean     $autocreate  Autocreate the plugin.
+	 * @param   Dispatcher  $dispatcher  Optionally allows the plugin to use a different dispatcher.
 	 *
 	 * @return  boolean  True on success.
 	 *

--- a/libraries/cms/plugin/plugin.php
+++ b/libraries/cms/plugin/plugin.php
@@ -185,6 +185,8 @@ abstract class JPlugin implements DispatcherAwareInterface
 	 * argument.
 	 *
 	 * @return  void
+	 *
+	 * @since   4.0
 	 */
 	protected function registerListeners()
 	{
@@ -245,63 +247,69 @@ abstract class JPlugin implements DispatcherAwareInterface
 	 * the Event, as an element into an array argument called 'result'.
 	 *
 	 * @param   string  $methodName  The method name to register
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
 	 */
 	protected final function registerLegacyListener($methodName)
 	{
-		$this->getDispatcher()->addListener($methodName, function(AbstractEvent $event) use ($methodName) {
-			// Get the event arguments
-			$arguments = $event->getArguments();
+		$this->getDispatcher()->addListener(
+			$methodName, function(AbstractEvent $event) use ($methodName) {
+				// Get the event arguments
+				$arguments = $event->getArguments();
 
-			// Map the associative argument array to a numeric indexed array for efficiency (see the switch statement below).
-			$arguments = array_values($arguments);
+				// Map the associative argument array to a numeric indexed array for efficiency (see the switch statement below).
+				$arguments = array_values($arguments);
 
-			// Extract any old results; they must not be part of the method call.
-			$allResults = [];
+				// Extract any old results; they must not be part of the method call.
+				$allResults = [];
 
-			if (isset($arguments['result']))
-			{
-				$allResults = $arguments['result'];
+				if (isset($arguments['result']))
+				{
+					$allResults = $arguments['result'];
 
-				unset($arguments['result']);
+					unset($arguments['result']);
+				}
+
+				/**
+				 * Calling the method directly is faster than using call_user_func_array, hence this argument
+				 * unpacking switch statement. Please do not wrap it back to a single line, it will hurt performance.
+				 *
+				 * If we raise minimum requirements to PHP 5.6 we can use array unpacking and remove the switch for
+				 * even better results, i.e. replace the switch with:
+				 * $result = $this->{$methodName}(...$arguments);
+				 */
+				switch (count($arguments))
+				{
+					case 0:
+						$result = $this->{$methodName}();
+						break;
+					case 1:
+						$result = $this->{$methodName}($arguments[0]);
+						break;
+					case 2:
+						$result = $this->{$methodName}($arguments[0], $arguments[1]);
+						break;
+					case 3:
+						$result = $this->{$methodName}($arguments[0], $arguments[1], $arguments[2]);
+						break;
+					case 4:
+						$result = $this->{$methodName}($arguments[0], $arguments[1], $arguments[2], $arguments[3]);
+						break;
+					case 5:
+						$result = $this->{$methodName}($arguments[0], $arguments[1], $arguments[2], $arguments[3], $arguments[4]);
+						break;
+					default:
+						$result = call_user_func_array(array($this, $methodName), $arguments);
+						break;
+				}
+
+				// Restore the old results and add the new result from our method call
+				array_push($allResults, $result);
+				$event['result'] = $allResults;
 			}
-
-			/**
-			 * Calling the method directly is faster than using call_user_func_array, hence this argument
-			 * unpacking switch statement. Please do not wrap it back to a single line, it will hurt performance.
-			 *
-			 * If we raise minimum requirements to PHP 5.6 we can use array unpacking and remove the switch for
-			 * even better results, i.e. replace the switch with:
-			 * $result = $this->{$methodName}(...$arguments);
-			 */
-			switch (count($arguments))
-			{
-				case 0:
-					$result = $this->{$methodName}();
-					break;
-				case 1:
-					$result = $this->{$methodName}($arguments[0]);
-					break;
-				case 2:
-					$result = $this->{$methodName}($arguments[0], $arguments[1]);
-					break;
-				case 3:
-					$result = $this->{$methodName}($arguments[0], $arguments[1], $arguments[2]);
-					break;
-				case 4:
-					$result = $this->{$methodName}($arguments[0], $arguments[1], $arguments[2], $arguments[3]);
-					break;
-				case 5:
-					$result = $this->{$methodName}($arguments[0], $arguments[1], $arguments[2], $arguments[3], $arguments[4]);
-					break;
-				default:
-					$result = call_user_func_array(array($this, $methodName), $arguments);
-					break;
-			}
-
-			// Restore the old results and add the new result from our method call
-			array_push($allResults, $result);
-			$event['result'] = $allResults;
-		});
+		);
 	}
 
 	/**
@@ -309,6 +317,10 @@ abstract class JPlugin implements DispatcherAwareInterface
 	 * preferred way to implement plugins in Joomla! 4.x and will be the only possible method with Joomla! 5.x onwards.
 	 *
 	 * @param   string  $methodName  The method name to register
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0
 	 */
 	protected final function registerListener($methodName)
 	{

--- a/libraries/joomla/application/base.php
+++ b/libraries/joomla/application/base.php
@@ -121,8 +121,8 @@ abstract class JApplicationBase extends AbstractApplication
 	 *
 	 * This method will only return the 'result' argument of the event
 	 *
-	 * @param   string        $eventName  The event name.
-	 * @param   array|Event   $args       An array of arguments or an Event object (optional).
+	 * @param   string       $eventName  The event name.
+	 * @param   array|Event  $args       An array of arguments or an Event object (optional).
 	 *
 	 * @return  array   An array of results from each function call, or null if no dispatcher is defined.
 	 *
@@ -174,7 +174,7 @@ abstract class JApplicationBase extends AbstractApplication
 	 */
 	public function loadDispatcher(DispatcherInterface $dispatcher = null)
 	{
-		$this->dispatcher = ($dispatcher === null) ? new Dispatcher() : $dispatcher;
+		$this->dispatcher = ($dispatcher === null) ? new Dispatcher : $dispatcher;
 
 		return $this;
 	}

--- a/libraries/joomla/application/cli.php
+++ b/libraries/joomla/application/cli.php
@@ -35,16 +35,16 @@ class JApplicationCli extends JApplicationBase
 	/**
 	 * Class constructor.
 	 *
-	 * @param   JInputCli         $input       An optional argument to provide dependency injection for the application's
-	 *                                         input object.  If the argument is a JInputCli object that object will become
-	 *                                         the application's input object, otherwise a default input object is created.
-	 * @param   Registry          $config      An optional argument to provide dependency injection for the application's
-	 *                                         config object.  If the argument is a Registry object that object will become
-	 *                                         the application's config object, otherwise a default config object is created.
+	 * @param   JInputCli            $input       An optional argument to provide dependency injection for the application's
+	 *                                            input object.  If the argument is a JInputCli object that object will become
+	 *                                            the application's input object, otherwise a default input object is created.
+	 * @param   Registry             $config      An optional argument to provide dependency injection for the application's
+	 *                                            config object.  If the argument is a Registry object that object will become
+	 *                                            the application's config object, otherwise a default config object is created.
 	 * @param   DispatcherInterface  $dispatcher  An optional argument to provide dependency injection for the application's
-	 *                                         event dispatcher.  If the argument is a DispatcherInterface object that object will become
-	 *                                         the application's event dispatcher, if it is null then the default event dispatcher
-	 *                                         will be created based on the application's loadDispatcher() method.
+	 *                                            event dispatcher.  If the argument is a DispatcherInterface object that object will become
+	 *                                            the application's event dispatcher, if it is null then the default event dispatcher
+	 *                                            will be created based on the application's loadDispatcher() method.
 	 *
 	 * @see     JApplicationBase::loadDispatcher()
 	 * @since   11.1

--- a/libraries/joomla/application/daemon.php
+++ b/libraries/joomla/application/daemon.php
@@ -94,16 +94,16 @@ class JApplicationDaemon extends JApplicationCli
 	/**
 	 * Class constructor.
 	 *
-	 * @param   JInputCli         $input       An optional argument to provide dependency injection for the application's
-	 *                                         input object.  If the argument is a JInputCli object that object will become
-	 *                                         the application's input object, otherwise a default input object is created.
-	 * @param   Registry          $config      An optional argument to provide dependency injection for the application's
-	 *                                         config object.  If the argument is a Registry object that object will become
-	 *                                         the application's config object, otherwise a default config object is created.
+	 * @param   JInputCli            $input       An optional argument to provide dependency injection for the application's
+	 *                                            input object.  If the argument is a JInputCli object that object will become
+	 *                                            the application's input object, otherwise a default input object is created.
+	 * @param   Registry             $config      An optional argument to provide dependency injection for the application's
+	 *                                            config object.  If the argument is a Registry object that object will become
+	 *                                            the application's config object, otherwise a default config object is created.
 	 * @param   DispatcherInterface  $dispatcher  An optional argument to provide dependency injection for the application's
-	 *                                         event dispatcher.  If the argument is a DispatcherInterface object that object will become
-	 *                                         the application's event dispatcher, if it is null then the default event dispatcher
-	 *                                         will be created based on the application's loadDispatcher() method.
+	 *                                            event dispatcher.  If the argument is a DispatcherInterface object that object will become
+	 *                                            the application's event dispatcher, if it is null then the default event dispatcher
+	 *                                            will be created based on the application's loadDispatcher() method.
 	 *
 	 * @since   11.1
 	 * @throws  RuntimeException

--- a/libraries/joomla/table/table.php
+++ b/libraries/joomla/table/table.php
@@ -613,7 +613,6 @@ abstract class JTable extends JObject implements JTableInterface, DispatcherAwar
 		]);
 		$this->getDispatcher()->dispatch('onTableBeforeBind', $event);
 
-
 		// JSON encode any fields required
 		if (!empty($this->_jsonEncode))
 		{
@@ -827,7 +826,6 @@ abstract class JTable extends JObject implements JTableInterface, DispatcherAwar
 			'k'				=> $k,
 		]);
 		$this->getDispatcher()->dispatch('onTableBeforeStore', $event);
-
 
 		$currentAssetId = 0;
 
@@ -1050,7 +1048,6 @@ abstract class JTable extends JObject implements JTableInterface, DispatcherAwar
 			'pk'		=> $pk,
 		]);
 		$this->getDispatcher()->dispatch('onTableBeforeDelete', $event);
-
 
 		// If tracking assets, remove the asset first.
 		if ($this->_trackAssets)
@@ -1652,7 +1649,6 @@ abstract class JTable extends JObject implements JTableInterface, DispatcherAwar
 			'where'		=> $where,
 		]);
 		$this->getDispatcher()->dispatch('onTableAfterMove', $event);
-
 
 		return true;
 	}

--- a/libraries/joomla/user/authentication.php
+++ b/libraries/joomla/user/authentication.php
@@ -14,6 +14,8 @@ use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Event\Dispatcher;
 
+JLoader::register('JAuthenticationResponse', __DIR__ . '/response.php');
+
 /**
  * Authentication class, provides an interface for the Joomla authentication system
  *
@@ -83,13 +85,10 @@ class JAuthentication implements DispatcherAwareInterface
 	 */
 	public function __construct(DispatcherInterface $dispatcher = null)
 	{
-		// Pre-load JAuthenticationResponse (it's not resolved by the autoloader)
-		require_once 'response.php'; // Because JLoader::import won't include class files for classes not following its particular naming scheme. If you want to waste 2 hours of your life refactor it, I'm done.
-
 		// Set the dispatcher
 		if (!is_object($dispatcher))
 		{
-			$dispatcher = new Dispatcher();
+			$dispatcher = new Dispatcher;
 		}
 
 		$this->setDispatcher($dispatcher);
@@ -120,8 +119,6 @@ class JAuthentication implements DispatcherAwareInterface
 
 		return self::$instance;
 	}
-
-
 
 	/**
 	 * Finds out if a set of login credentials are valid by asking all observing

--- a/libraries/legacy/application/cli.php
+++ b/libraries/legacy/application/cli.php
@@ -24,16 +24,16 @@ class JCli extends JApplicationCli
 	/**
 	 * Class constructor.
 	 *
-	 * @param   JInputCli         $input       An optional argument to provide dependency injection for the application's
-	 *                                         input object.  If the argument is a JInputCli object that object will become
-	 *                                         the application's input object, otherwise a default input object is created.
-	 * @param   Registry          $config      An optional argument to provide dependency injection for the application's
-	 *                                         config object.  If the argument is a Registry object that object will become
-	 *                                         the application's config object, otherwise a default config object is created.
+	 * @param   JInputCli            $input       An optional argument to provide dependency injection for the application's
+	 *                                            input object.  If the argument is a JInputCli object that object will become
+	 *                                            the application's input object, otherwise a default input object is created.
+	 * @param   Registry             $config      An optional argument to provide dependency injection for the application's
+	 *                                            config object.  If the argument is a Registry object that object will become
+	 *                                            the application's config object, otherwise a default config object is created.
 	 * @param   DispatcherInterface  $dispatcher  An optional argument to provide dependency injection for the application's
-	 *                                         event dispatcher.  If the argument is a DispatcherInterface object that object will become
-	 *                                         the application's event dispatcher, if it is null then the default event dispatcher
-	 *                                         will be created based on the application's loadDispatcher() method.
+	 *                                            event dispatcher.  If the argument is a DispatcherInterface object that object will become
+	 *                                            the application's event dispatcher, if it is null then the default event dispatcher
+	 *                                            will be created based on the application's loadDispatcher() method.
 	 *
 	 * @see     JApplicationBase::loadDispatcher()
 	 * @since   11.1

--- a/libraries/legacy/application/daemon.php
+++ b/libraries/legacy/application/daemon.php
@@ -26,16 +26,16 @@ class JDaemon extends JApplicationDaemon
 	/**
 	 * Class constructor.
 	 *
-	 * @param   JInputCli         $input       An optional argument to provide dependency injection for the application's
-	 *                                         input object.  If the argument is a JInputCli object that object will become
-	 *                                         the application's input object, otherwise a default input object is created.
-	 * @param   Registry          $config      An optional argument to provide dependency injection for the application's
-	 *                                         config object.  If the argument is a Registry object that object will become
-	 *                                         the application's config object, otherwise a default config object is created.
+	 * @param   JInputCli            $input       An optional argument to provide dependency injection for the application's
+	 *                                            input object.  If the argument is a JInputCli object that object will become
+	 *                                            the application's input object, otherwise a default input object is created.
+	 * @param   Registry             $config      An optional argument to provide dependency injection for the application's
+	 *                                            config object.  If the argument is a Registry object that object will become
+	 *                                            the application's config object, otherwise a default config object is created.
 	 * @param   DispatcherInterface  $dispatcher  An optional argument to provide dependency injection for the application's
-	 *                                         event dispatcher.  If the argument is a DispatcherInterface object that object will become
-	 *                                         the application's event dispatcher, if it is null then the default event dispatcher
-	 *                                         will be created based on the application's loadDispatcher() method.
+	 *                                            event dispatcher.  If the argument is a DispatcherInterface object that object will become
+	 *                                            the application's event dispatcher, if it is null then the default event dispatcher
+	 *                                            will be created based on the application's loadDispatcher() method.
 	 *
 	 * @since   11.1
 	 * @deprecated  12.3 Use JApplicationDaemon instead.

--- a/libraries/legacy/model/admin.php
+++ b/libraries/legacy/model/admin.php
@@ -600,11 +600,14 @@ abstract class JModelAdmin extends JModelForm
 				$table->load($pk);
 				$tags = array($value);
 
-				$setTagsEvent = Joomla\Cms\Event\AbstractEvent::create('TableSetNewTags', array(
-					'subject'		=> $this,
-					'newTags'		=> $tags,
-					'replaceTags'	=> false
-				));
+				$setTagsEvent = Joomla\Cms\Event\AbstractEvent::create(
+					'TableSetNewTags',
+					array(
+						'subject'		=> $this,
+						'newTags'		=> $tags,
+						'replaceTags'	=> false
+					)
+				);
 
 				try
 				{

--- a/plugins/behaviour/taggable/taggable.php
+++ b/plugins/behaviour/taggable/taggable.php
@@ -17,19 +17,19 @@ use Joomla\Cms\Event as CmsEvent;
  *
  * This plugin supersedes JHelperObserverTags.
  *
- * @since   4.0.0
+ * @since  4.0.0
  */
 class PlgBehaviourTaggable extends JPlugin
 {
 	/**
 	 * Constructor
 	 *
-	 * @param   DispatcherInterface &$subject   The object to observe
-	 * @param   array               $config     An optional associative array of configuration settings.
+	 * @param   DispatcherInterface  &$subject  The object to observe
+	 * @param   array                $config    An optional associative array of configuration settings.
 	 *                                          Recognized key values include 'name', 'group', 'params', 'language'
 	 *                                          (this list is not meant to be comprehensive).
 	 *
-	 * @since   1.5
+	 * @since   4.0
 	 */
 	public function __construct(&$subject, $config = array())
 	{
@@ -42,6 +42,10 @@ class PlgBehaviourTaggable extends JPlugin
 	 * Runs when a new table object is being created
 	 *
 	 * @param   CmsEvent\Table\ObjectCreateEvent  $event  The event to handle
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
 	 */
 	public function onTableObjectCreate(CmsEvent\Table\ObjectCreateEvent $event)
 	{
@@ -255,6 +259,10 @@ class PlgBehaviourTaggable extends JPlugin
 	 * Runs when an existing table object is reset
 	 *
 	 * @param   CmsEvent\Table\AfterResetEvent  $event  The event to handle
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
 	 */
 	public function onTableAfterReset(CmsEvent\Table\AfterResetEvent $event)
 	{
@@ -279,6 +287,10 @@ class PlgBehaviourTaggable extends JPlugin
 	 * Runs when an existing table object is reset
 	 *
 	 * @param   CmsEvent\Table\AfterLoadEvent  $event  The event to handle
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
 	 */
 	public function onTableAfterLoad(CmsEvent\Table\AfterLoadEvent $event)
 	{
@@ -315,7 +327,7 @@ class PlgBehaviourTaggable extends JPlugin
 	 * Internal method
 	 * Parses a TypeAlias of the form "{variableName}.type", replacing {variableName} with table-instance variables variableName
 	 *
-	 * @param   JTableInterface  $table  The table
+	 * @param   JTableInterface  &$table  The table
 	 *
 	 * @return  string
 	 *

--- a/plugins/behaviour/versionable/versionable.php
+++ b/plugins/behaviour/versionable/versionable.php
@@ -17,7 +17,7 @@ use Joomla\Cms\Event as CmsEvent;
  *
  * This plugin supersedes JTableObserverContenthistory.
  *
- * @since   4.0.0
+ * @since  4.0.0
  */
 class PlgBehaviourVersionable extends JPlugin
 {

--- a/plugins/behaviour/versionable/versionable.php
+++ b/plugins/behaviour/versionable/versionable.php
@@ -24,12 +24,12 @@ class PlgBehaviourVersionable extends JPlugin
 	/**
 	 * Constructor
 	 *
-	 * @param   DispatcherInterface &$subject   The object to observe
-	 * @param   array               $config     An optional associative array of configuration settings.
+	 * @param   DispatcherInterface  &$subject  The object to observe
+	 * @param   array                $config    An optional associative array of configuration settings.
 	 *                                          Recognized key values include 'name', 'group', 'params', 'language'
 	 *                                          (this list is not meant to be comprehensive).
 	 *
-	 * @since   1.5
+	 * @since   4.0
 	 */
 	public function __construct(&$subject, $config = array())
 	{
@@ -42,12 +42,16 @@ class PlgBehaviourVersionable extends JPlugin
 	 * Runs when a new table object is being created
 	 *
 	 * @param   CmsEvent\Table\ObjectCreateEvent  $event  The event to handle
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
 	 */
 	public function onTableObjectCreate(CmsEvent\Table\ObjectCreateEvent $event)
 	{
 		// Extract arguments
 		/** @var JTableInterface $table */
-		$table			= $event['subject'];
+		$table = $event['subject'];
 
 		// When we create the object the table is empty, so we can't parse the typeAlias field
 		$typeAlias = $table->typeAlias;
@@ -163,7 +167,7 @@ class PlgBehaviourVersionable extends JPlugin
 	 * Internal method
 	 * Parses a TypeAlias of the form "{variableName}.type", replacing {variableName} with table-instance variables variableName
 	 *
-	 * @param   JTableInterface  $table  The table
+	 * @param   JTableInterface  &$table  The table
 	 *
 	 * @return  string
 	 *

--- a/plugins/editors-xtd/readmore/readmore.php
+++ b/plugins/editors-xtd/readmore/readmore.php
@@ -37,9 +37,12 @@ class PlgButtonReadmore extends JPlugin
 
 		// Button is not active in specific content components
 
-		$event = new \Joomla\Event\Event('getContent', [
-			'name' => $name
-		]);
+		$event = new \Joomla\Event\Event(
+			'getContent',
+			[
+				'name' => $name
+			]
+		);
 		$getContentResult = $this->getDispatcher()->dispatch('getContent', $event);
 		$getContent = $getContentResult['result'][0];
 		$present = JText::_('PLG_READMORE_ALREADY_EXISTS', true);

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -942,12 +942,15 @@ class PlgEditorTinymce extends JPlugin
 
 		if (is_array($buttons) || (is_bool($buttons) && $buttons))
 		{
-			$buttonsEvent = new Event('getButtons', [
-				'name'		=> $name,
-				'buttons'	=> $buttons,
-				'asset'		=> $asset,
-				'author'	=> $author
-			]);
+			$buttonsEvent = new Event(
+				'getButtons',
+				[
+					'name'		=> $name,
+					'buttons'	=> $buttons,
+					'asset'		=> $asset,
+					'author'	=> $author
+				]
+			);
 
 			$buttonsResult = $this->getDispatcher()->dispatch('getButtons', $buttonsEvent);
 


### PR DESCRIPTION
From @nikosdion 's PR that we previously merged. Also fixes two code issues.
1. `JAuthenticationResponse` is now autoloaded through `JLoader` as per the todo comment in the code
2. `SetNewTagsEvent` now extends `AbstractEvent` instead of a mysterious `TableEvent` which as far as I can tell doesn't exist (i think it's just a typo - if @nikosdion could confirm?)

Note that I haven't touched the codestyle issue in the `JTable` with the creation of events because I'd spent over 2 hours on this and I was tired and wanted sleep and my sanity back. Otherwise I've nailed everything else.
