### PR TITLE
Fixed deprecated parameter for Yaml::parse()

### DIFF
--- a/libraries/incubator/Extension/FileExtensionFactory.php
+++ b/libraries/incubator/Extension/FileExtensionFactory.php
@@ -95,7 +95,7 @@ class FileExtensionFactory implements ExtensionFactoryInterface
 			$this->loadedFiles[$path]    = $extension;
 			$this->extensions[$group][]  = $extension;
 
-			$config = Yaml::parse($fs->read($file['path'])['contents'], true);
+			$config = Yaml::parse($fs->read($file['path'])['contents'], Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE);
 
 			if (key_exists('listeners', $config))
 			{


### PR DESCRIPTION
Removes the message

> DEPRECATION: Passing a boolean flag to toggle exception handling is deprecated since version 3.1 and will be removed in 4.0. Use the PARSE_EXCEPTION_ON_INVALID_TYPE flag instead. /home/nibra/Development/joomla-pythagoras/libraries/vendor/symfony/yaml/Yaml.php:51

that appeared during unit testing.
