### PR TITLE
Feature/installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-rm -f data/sqlite.db && rm -f data/entities/*.xml && ./joomla install \
+rm -f data/entities/*.xml && ./joomla install \
     extensions/Article \
     libraries/incubator/Media \
     libraries/incubator/PageBuilder

--- a/libraries/incubator/Cms/Installer/Installer.php
+++ b/libraries/incubator/Cms/Installer/Installer.php
@@ -170,7 +170,7 @@ class Installer
 		foreach ($this->entityDefinitions as $definition)
 		{
 			$this->resolveBelongsTo($definition);
-			$this->resolveHasOnOrMany($definition);
+			$this->resolveHasOneOrMany($definition);
 			$this->resolveHasManyThrough($definition);
 		}
 
@@ -323,7 +323,7 @@ class Installer
 	 *
 	 * @return  void
 	 */
-	private function resolveHasOnOrMany($definition)
+	private function resolveHasOneOrMany($definition)
 	{
 		foreach (array_merge($definition->relations['hasMany'], $definition->relations['hasOne']) as $relation)
 		{

--- a/libraries/incubator/Cms/Installer/Installer.php
+++ b/libraries/incubator/Cms/Installer/Installer.php
@@ -286,15 +286,7 @@ class Installer
 			$counterMeta      = $this->entityDefinitions[$counterEntity];
 			$counterRelations = $counterMeta->relations;
 
-			foreach ($counterRelations['hasOne'] as $counterRelation)
-			{
-				if ($counterRelation->entity == $definition->name && $counterRelation->reference == $relation->name)
-				{
-					break 2;
-				}
-			}
-
-			foreach ($counterRelations['hasMany'] as $counterRelation)
+			foreach (array_merge($counterRelations['hasOne'], $counterRelations['hasMany']) as $counterRelation)
 			{
 				if ($counterRelation->entity == $definition->name && $counterRelation->reference == $relation->name)
 				{
@@ -310,7 +302,8 @@ class Installer
 					'reference' => $relation->name,
 				]
 			);
-			$counterRelations['hasMany'][$counterRelation->name] = $counterRelation;
+
+			$this->entityDefinitions[$counterEntity]->relations['hasMany'][$counterRelation->name] = $counterRelation;
 		}
 	}
 
@@ -342,7 +335,8 @@ class Installer
 					'entity' => $definition->name,
 				]
 			);
-			$counterRelations['belongsTo'][$counterRelation->name] = $counterRelation;
+
+			$this->entityDefinitions[$counterEntity]->relations['belongsTo'][$counterRelation->name] = $counterRelation;
 		}
 	}
 

--- a/libraries/incubator/Cms/Installer/Installer.php
+++ b/libraries/incubator/Cms/Installer/Installer.php
@@ -13,11 +13,7 @@ use Joomla\DI\Container;
 use Joomla\ORM\Definition\Locator\Strategy\RecursiveDirectoryStrategy;
 use Joomla\ORM\Definition\Parser\BelongsTo;
 use Joomla\ORM\Definition\Parser\Entity as EntityStructure;
-use Joomla\ORM\Definition\Parser\Field;
 use Joomla\ORM\Definition\Parser\HasMany;
-use Joomla\ORM\Definition\Parser\HasManyThrough;
-use Joomla\ORM\Definition\Parser\HasOne;
-use Joomla\ORM\Definition\Parser\Relation;
 use Joomla\ORM\Entity\EntityBuilder;
 use Joomla\ORM\Service\RepositoryFactory;
 use Joomla\ORM\Service\StorageServiceProvider;
@@ -54,7 +50,7 @@ class Installer
 	/**
 	 * Installer constructor.
 	 *
-	 * @param   string  $dataDirectory  The data directory
+	 * @param   string $dataDirectory The data directory
 	 */
 	public function __construct($dataDirectory)
 	{
@@ -74,7 +70,7 @@ class Installer
 	/**
 	 * Installs an extension
 	 *
-	 * @param   string  $source  The path to the extension
+	 * @param   string $source The path to the extension
 	 *
 	 * @return  void
 	 */
@@ -131,7 +127,7 @@ class Installer
 	/**
 	 * Load the data from the file
 	 *
-	 * @param   string  $dataFile  A filename
+	 * @param   string $dataFile A filename
 	 *
 	 * @return  array   The data
 	 */
@@ -200,7 +196,7 @@ class Installer
 	}
 
 	/**
-	 * @param   string  $pattern  A filename pattern
+	 * @param   string $pattern A filename pattern
 	 *
 	 * @return  string[]  A list of entity names
 	 */
@@ -232,7 +228,7 @@ class Installer
 	}
 
 	/**
-	 * @param   string  $entityName  The name of the entity
+	 * @param   string $entityName The name of the entity
 	 *
 	 * @return  void
 	 */
@@ -263,12 +259,12 @@ class Installer
 			$primary = explode(',', $meta->primary);
 			$table->setPrimaryKey($primary);
 
-			$schemaManager->createTable($table);
+			$schemaManager->dropAndCreateTable($table);
 		}
 	}
 
 	/**
-	 * @param   string  $word  A word
+	 * @param   string $word A word
 	 *
 	 * @return  string
 	 */

--- a/tests/unit/Cms/Installer/InstallerTest.php
+++ b/tests/unit/Cms/Installer/InstallerTest.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Part of the Joomla CMS Installer Package Test Suite
+ *
+ * @copyright  Copyright (C) 2015 - 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Tests\Unit\Cms\Installer;
+
+use Joomla\Cms\Installer\Installer;
+
+class InstallerTest extends \PHPUnit_Framework_TestCase
+{
+	/** @var  Installer */
+	private $installer;
+
+	/** @var  string */
+	private $dataDirectory;
+
+	public function setUp()
+	{
+		$this->dataDirectory = __DIR__ . '/tmp';
+		mkdir($this->dataDirectory);
+		mkdir($this->dataDirectory . '/entities');
+
+		$this->installer = new Installer($this->dataDirectory);
+	}
+
+	public function tearDown()
+	{
+
+		foreach (glob($this->dataDirectory . '/entities/*') as $file)
+		{
+			unlink($file);
+		}
+		rmdir($this->dataDirectory . '/entities');
+		rmdir($this->dataDirectory);
+	}
+
+	public function testInstallASingleExtension()
+	{
+		$this->installer->install(__DIR__ . '/data/ext_article');
+		$this->installer->finish();
+
+		$this->assertFileExists($this->dataDirectory . '/entities/Article.xml');
+	}
+}

--- a/tests/unit/Cms/Installer/InstallerTest.php
+++ b/tests/unit/Cms/Installer/InstallerTest.php
@@ -8,6 +8,7 @@
 
 namespace Joomla\Tests\Unit\Cms\Installer;
 
+use DOMDocument;
 use Joomla\Cms\Installer\Installer;
 
 class InstallerTest extends \PHPUnit_Framework_TestCase
@@ -38,11 +39,78 @@ class InstallerTest extends \PHPUnit_Framework_TestCase
 		rmdir($this->dataDirectory);
 	}
 
+	/**
+	 * @testdox Without relations, an entity definition is cached as is
+	 */
 	public function testInstallASingleExtension()
 	{
 		$this->installer->install(__DIR__ . '/data/ext_article');
 		$this->installer->finish();
 
 		$this->assertFileExists($this->dataDirectory . '/entities/Article.xml');
+
+		$expected = new DOMDocument;
+		$expected->load(__DIR__ . '/data/ext_article/entities/Article.xml');
+		$actual   = new DOMDocument;
+		$actual->load($this->dataDirectory . '/entities/Article.xml');
+
+		$this->assertEquals($this->getStructure($expected->documentElement), $this->getStructure($actual->documentElement));
+	}
+
+	/**
+	 * @testdox belongsTo relations from one entity create a hasMany relationship on the other.
+	 */
+	public function testResolveBelongsTo()
+	{
+		$this->installer->install(__DIR__ . '/data/ext_article');
+		$this->installer->install(__DIR__ . '/data/ext_extra');
+		$this->installer->finish();
+
+		$expected = new DOMDocument;
+		$expected->load(__DIR__ . '/data/ext_article/entities/Article.xml');
+		$expectedStructure = $this->getStructure($expected->documentElement);
+
+		$this->assertFalse(in_array('extras', $expectedStructure['relations']['hasMany']));
+
+		$actual = new DOMDocument;
+		$actual->load($this->dataDirectory . '/entities/Article.xml');
+		$actualStructure = $this->getStructure($actual->documentElement);
+
+		$this->assertTrue(in_array('extras', $actualStructure['relations']['hasMany']));
+	}
+
+	protected function getStructure(\DOMElement $node)
+	{
+		$structure = [];
+
+		if ($node->hasChildNodes())
+		{
+			foreach ($node->childNodes as $child)
+			{
+				if ($child->nodeType != XML_ELEMENT_NODE)
+				{
+					continue;
+				}
+
+				/** @var \DOMElement $child */
+				$name = null;
+
+				if ($child->hasAttributes())
+				{
+					$attribute = $child->attributes->getNamedItem('name');
+					$name      = !empty($attribute) ? $attribute->nodeValue : null;
+				}
+
+				if (!empty($name))
+				{
+					$structure[$child->nodeName][] = $name;
+					continue;
+				}
+
+				$structure[$child->nodeName] = $this->getStructure($child);
+			}
+		}
+
+		return $structure;
 	}
 }

--- a/tests/unit/Cms/Installer/data/ext_article/entities/Article.xml
+++ b/tests/unit/Cms/Installer/data/ext_article/entities/Article.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE entity SYSTEM
+    "https://github.com/nibralab/joomla-architecture/blob/master/code/Joomla/ORM/Definition/entity.dtd">
+<entity name="Joomla\Extension\Article\Entity\Article">
+
+    <storage>
+        <default table="articles"/>
+    </storage>
+
+    <fields>
+        <field name="id"
+               type="id"
+               label="JGLOBAL_FIELD_ID_LABEL"
+               description="JGLOBAL_FIELD_ID_DESC"
+               default="null"
+        >
+            <validation rule="positive"/>
+            <validation rule="integer"/>
+        </field>
+
+        <field name="title"
+               type="title"
+               label="JGLOBAL_TITLE"
+        >
+            <validation rule="maxlen" value="64"/>
+        </field>
+
+        <field name="category"
+               type="text"
+        />
+
+        <field name="alias"
+               type="text"
+               label="JGLOBAL_FIELD_ALIAS_LABEL"
+               description="JGLOBAL_FIELD_ALIAS_DESC"
+        />
+
+        <field name="teaser"
+               type="richtext"
+               label="COM_CONTENT_FIELD_ARTICLETEXT_LABEL"
+               description="COM_CONTENT_FIELD_ARTICLETEXT_DESC"
+        />
+
+        <field name="body"
+               type="richtext"
+               label="COM_CONTENT_FIELD_ARTICLETEXT_LABEL"
+               description="COM_CONTENT_FIELD_ARTICLETEXT_DESC"
+        />
+
+        <field name="author"
+               type="text"
+               label="COM_CONTENT_FIELD_CREATED_BY_ALIAS_LABEL"
+               description="COM_CONTENT_FIELD_CREATED_BY_ALIAS_DESC"
+               default=""
+        />
+
+        <field name="license"
+               type="text"
+               label="JFIELD_META_RIGHTS_LABEL"
+               description="JFIELD_META_RIGHTS_DESC"
+        >
+            <validation rule="regex" value="copy(right|left)"/>
+        </field>
+
+    </fields>
+
+    <relations>
+        <belongsTo name="parent_id"
+                   entity="Article"
+                   label="JFIELD_PARENT_LABEL"
+                   description="JFIELD_PARENT_DESC"
+        />
+        <hasMany name="children"
+                 entity="Article"
+                 reference="parent_id"
+        />
+    </relations>
+
+</entity>

--- a/tests/unit/Cms/Installer/data/ext_category/entities/Category.xml
+++ b/tests/unit/Cms/Installer/data/ext_category/entities/Category.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE entity SYSTEM
+    "https://github.com/nibralab/joomla-architecture/blob/master/code/Joomla/ORM/Definition/entity.dtd">
+<entity name="Joomla\Tests\Unit\Cms\Installer\Category">
+
+    <storage>
+        <default table="categories"/>
+    </storage>
+
+    <fields>
+        <field name="id" type="id"/>
+        <field name="title" type="text" default=""/>
+    </fields>
+
+    <relations>
+        <hasMany name="articles" entity="Article" reference="category_id"/>
+    </relations>
+
+</entity>

--- a/tests/unit/Cms/Installer/data/ext_extra/entities/Extra.xml
+++ b/tests/unit/Cms/Installer/data/ext_extra/entities/Extra.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE entity SYSTEM
+    "https://github.com/nibralab/joomla-architecture/blob/master/code/Joomla/ORM/Definition/entity.dtd">
+<entity name="Joomla\Tests\Unit\ORM\Mocks\Extra">
+
+    <storage>
+        <default table="extras" primary="article_id"/>
+    </storage>
+
+    <fields>
+        <field name="info" type="text" default=""/>
+    </fields>
+
+    <relations>
+        <belongsTo
+            name="article_id"
+            entity="Article"
+        />
+    </relations>
+
+</entity>


### PR DESCRIPTION
Some improvements to the installer:
- Counter-relations for `belongsTo`, `hasOne` and `hasMany` are created when not already defined.
- Foreign keys to newly created `belongsTo` relations are added to the table structure.

Added unit tests for the installer.
